### PR TITLE
DATA-1741-amend-unique-test

### DIFF
--- a/models/intermediate/int_lever__interview_feedback.sql
+++ b/models/intermediate/int_lever__interview_feedback.sql
@@ -42,3 +42,5 @@ join_w_feedback as (
 
 select *
 from join_w_feedback
+{# Adding condition for non-null feedback_form_id observations. dbt expectations unique test fails for null observations #}
+where feedback_form_id is not null


### PR DESCRIPTION
Current test (https://github.com/fivetran/dbt_lever/blob/master/models/intermediate/int_lever.yml#L24-L27) fails for null observations of feedback_form_id. Submitting PR to fix for this